### PR TITLE
Add solc 5 to AttributeRegistryInterface's pragma

### DIFF
--- a/contracts/AttributeRegistryInterface.sol
+++ b/contracts/AttributeRegistryInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25;
 
 
 /**


### PR DESCRIPTION
Allow AttributeRegistryInterface to be used by Solidity 5 projects as well.